### PR TITLE
Only query users in NTDS.users

### DIFF
--- a/dissect/database/ese/ntds/ntds.py
+++ b/dissect/database/ese/ntds/ntds.py
@@ -80,7 +80,7 @@ class NTDS:
 
     def users(self) -> Iterator[User]:
         """Get all user objects from the database."""
-        yield from self.search(objectCategory="person")
+        yield from self.search(objectCategory="person", objectClass="user")
 
     def computers(self) -> Iterator[Computer]:
         """Get all computer objects from the database."""


### PR DESCRIPTION
Currently the `NTDS.users` method queries all the `person` objectes. However, not all persons in an NTDS are actual users, some of them can be [contacts](https://learn.microsoft.com/en-us/windows/win32/adschema/c-contact) for example. This currently causes target to crash, since a `contact` does not have attributes such as `sam_account_name`.

After this MR we filter only on the `objectClass` user. 
