### PR TITLE
Skip over bad entries in UAL while parsing data

### DIFF
--- a/dissect/database/ese/record.py
+++ b/dissect/database/ese/record.py
@@ -199,6 +199,27 @@ class RecordData:
         self._get_tag_field = lru_cache(4096)(self._get_tag_field)
         self._find_tag_field_idx = lru_cache(4096)(self._find_tag_field_idx)
 
+    @property
+    def is_empty(self) -> bool:
+        """Return whether the record is a tombstone or empty (has no defined column data)."""
+        return self._last_fixed_id == 0 and self._last_variable_id == 0 and self._tagged_data_count == 0
+
+    def matches_schema(self) -> bool:
+        """Check if the record column layout is compatible with the table schema.
+
+        A record can have fewer columns than the table defines — missing columns are null.
+        A record with more columns most likely is corrupted (or written with another schema)
+        and cannot be parsed.
+        """
+        num_fixed, num_variable, num_tagged = self.table.column_counts
+        return all(
+            (
+                self._last_fixed_id <= num_fixed,
+                (self._last_variable_id - 127) <= num_variable,
+                self._tagged_data_count <= num_tagged,
+            )
+        )
+
     def get(self, column: Column, raw: bool = False, errors: str | None = "backslashreplace") -> RecordValue:
         """Retrieve the value for the specified column.
 
@@ -401,6 +422,8 @@ class RecordData:
             if not tag_field.is_null:
                 offset = self._tagged_data_start
                 value = self.data[offset + data_start : offset + data_end]
+            else:
+                value = None
         else:
             # If the column has a default, use that
             # If not, this defaults to None

--- a/dissect/database/ese/table.py
+++ b/dissect/database/ese/table.py
@@ -115,6 +115,19 @@ class Table:
         """Return a list of all the column names."""
         return list(self._column_name_map.keys())
 
+    @cached_property
+    def column_counts(self) -> tuple[int, int, int]:
+        """Return the number of fixed, variable and tagged columns in this table.
+
+        Returns:
+            A tuple of (fixed, variable, tagged) column counts.
+        """
+        return (
+            sum(c.is_fixed for c in self.columns),
+            sum(c.is_variable for c in self.columns),
+            sum(c.is_tagged for c in self.columns),
+        )
+
     @property
     def primary_index(self) -> Index | None:
         # It's generally the first index, but loop just in case

--- a/dissect/database/ese/tools/ual.py
+++ b/dissect/database/ese/tools/ual.py
@@ -34,6 +34,7 @@ class UAL:
         "InsertDate",
         "LastAccess",
         "LastSeen",
+        "LastSeenActive",  # Present in VIRTUALMACHINES table
     )
 
     def __init__(self, fh: BinaryIO):
@@ -49,6 +50,9 @@ class UAL:
             return None
 
         for record in table.records():
+            if record._data.is_empty or not record._data.matches_schema():
+                continue
+
             record_data = {}
 
             last_access_year = None

--- a/tests/_data/ese/tools/SumBadEntries.mdb.gz
+++ b/tests/_data/ese/tools/SumBadEntries.mdb.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e68cd66484512140c627d55e33b00f50092902d1a47f97806214c86d067f110
+size 58638

--- a/tests/ese/conftest.py
+++ b/tests/ese/conftest.py
@@ -63,3 +63,8 @@ def ual_db() -> Iterator[BinaryIO]:
 @pytest.fixture
 def certlog_db() -> Iterator[BinaryIO]:
     yield from open_file_gz("_data/ese/tools/CertLog.edb.gz")
+
+
+@pytest.fixture
+def ual_bad_entries_db() -> Iterator[BinaryIO]:
+    yield from open_file_gz("_data/ese/tools/SumBadEntries.mdb.gz")

--- a/tests/ese/test_table.py
+++ b/tests/ese/test_table.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import BinaryIO
 from unittest.mock import MagicMock
 
+from dissect.database.ese.ese import ESE
+from dissect.database.ese.record import RecordData
 from dissect.database.ese.table import Table
 
 
@@ -32,3 +35,29 @@ def test_find_index() -> None:
     assert table.find_index(["UnsignedByte"]) is None
     assert table.find_index(["Id", "Bit"]) == mock_idx_id
     assert table.find_index(["Bit", "SomethingElse"]) == mock_idx_bit
+
+
+def test_record_data_bad_entries(ual_bad_entries_db: BinaryIO) -> None:
+    db = ESE(ual_bad_entries_db)
+
+    clients = db.table("CLIENTS")
+    assert len(list(clients.records())) == 24
+
+    dns = db.table("DNS")
+    assert len(list(dns.records())) == 17
+
+    all_clients_nodes = list(clients.root.iter_leaf_nodes())
+    tombstones = sum(1 for n in all_clients_nodes if RecordData(clients, n).is_empty)
+    assert tombstones == 5
+
+    dns_tombstones = 0
+    dns_mismatch = 0
+    for node in dns.root.iter_leaf_nodes():
+        rd = RecordData(dns, node)
+        if rd.is_empty:
+            dns_tombstones += 1
+        elif not rd.matches_schema():
+            dns_mismatch += 1
+
+    assert dns_tombstones == 3
+    assert dns_mismatch == 2

--- a/tests/ese/tools/test_ual.py
+++ b/tests/ese/tools/test_ual.py
@@ -13,3 +13,16 @@ def test_ual(ual_db: BinaryIO) -> None:
     assert len(list(db.get_table_records("VIRTUALMACHINES"))) == 0
     assert len(list(db.get_table_records("DNS"))) == 12
     assert len(list(db.get_table_records("SYSTEM_IDENTITY"))) == 0
+
+
+def test_ual_skip_bad_entries(ual_bad_entries_db: BinaryIO) -> None:
+    ual = UAL(ual_bad_entries_db)
+
+    # CLIENTS have 24 entries (5 are empty (tombstones))
+    # DNS have 17 (3 empty and 2 with schema mismatch)
+    # They should be skipped
+    clients = list(ual.get_table_records("CLIENTS"))
+    dns = list(ual.get_table_records("DNS"))
+
+    assert len(clients) == 19
+    assert len(dns) == 12


### PR DESCRIPTION
While running `ual.clients_access` on one machine got this exception:

```
Traceback (most recent call last):
  File "/home/user/venv/bin/target-query", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/venv/dissect/dissect.target/dissect/target/tools/utils/cli.py", line 475, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/dissect/dissect.target/dissect/target/tools/query.py", line 260, in main
    for record in record_generator:
                  ^^^^^^^^^^^^^^^^
  File "/home/user/venv/dissect/dissect.target/dissect/target/plugins/os/windows/ual.py", line 226, in client_access
    for path, client_record in self.read_table_records("CLIENTS"):
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/dissect/dissect.target/dissect/target/plugins/os/windows/ual.py", line 219, in read_table_records
    for table_record in parser.get_table_records(table_name):
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/dissect/dissect.database/dissect/database/ese/tools/ual.py", line 61, in get_table_records
    value = wintimestamp(value)
            ^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/dissect/util/ts.py", line 187, in wintimestamp
    return _calculate_timestamp(float(ts) * 1e-7 - 11_644_473_600)  # Thanks FireEye
                                ^^^^^^^^^
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

`ual.clients_seen` gave me same exception, but now in `DNS` UAL table.

For `CLIENTS` table this was caused by entry without any data in it - all columns for it were not defined, so `None` was passed in `wintimestamp`, which gave exception.
For `DNS` table - faulty entry had more defined columns than DNS schema expected, which resulted in regular string passed to `wintimestamp`.

First i went with a fix to `wintimestamp` to use try-except and just return None on bad timestamps, but IMO it does not cover all cases, so instead I ended up adding verification for UAL entries to check if they are empty or matches table schema. For schema matching it just checks that entry does not have more columns than in schema (a lot of them have lower values, for ese it just means that value in that column is empty, as I understood).

`is_empty` and `matches_schema` can be used in another `ese` code, but since it will skip over data that can be carved in some cases (which can be useful), I limited it to just UAL.

Test for it was a real pain because of double checksumming with ECC in `ese`. Used existing test and added to it empty and schema-mismatch records to give same exceptions as in my case. DB is correct and can be parsed with Eric Zimmerman's `SumECmd` (but it requires patching to remove hardcoded requirement for `SystemIdentity.mdb`). I verified this test (and my faulty real UAL) against it to ensure that results matches.