### PR TITLE
Add XPRESS9, XPRESS10, LZ4 and SCRUB support

### DIFF
--- a/dissect/database/ese/compression.py
+++ b/dissect/database/ese/compression.py
@@ -1,50 +1,6 @@
 from __future__ import annotations
 
-import struct
+from ntcompress.ese import decompress
+from ntcompress.ese import decompressed_size as decompress_size
 
-from dissect.util.compression import lzxpress, sevenbit
-
-from dissect.database.ese.c_ese import COMPRESSION_SCHEME
-
-
-def decompress(buf: bytes) -> bytes:
-    """Decompress the given bytes according to the encoded compression scheme.
-
-    Args:
-        buf: The compressed bytes to decompress.
-
-    Raises:
-        NotImplementedError: If the buffer is compressed with an unsupported compression algorithm (XPRESS9/XPRESS10).
-    """
-    identifier = buf[0] >> 3
-    if identifier == COMPRESSION_SCHEME.COMPRESS_7BITASCII:
-        return sevenbit.decompress(buf[1:])
-    if identifier == COMPRESSION_SCHEME.COMPRESS_7BITUNICODE:
-        return sevenbit.decompress(buf[1:], wide=True)
-    if identifier == COMPRESSION_SCHEME.COMPRESS_XPRESS:
-        return lzxpress.decompress(buf[3:])
-    if identifier in (COMPRESSION_SCHEME.COMPRESS_XPRESS9, COMPRESSION_SCHEME.COMPRESS_XPRESS10):
-        raise NotImplementedError(f"Compression not yet implemented: {COMPRESSION_SCHEME(identifier)}")
-    # Not compressed
-    return buf
-
-
-def decompress_size(buf: bytes) -> int | None:
-    """Return the decompressed size of the given bytes according to the encoded compression scheme.
-
-    Args:
-        buf: The compressed bytes to return the decompressed size of.
-
-    Raises:
-        NotImplementedError: If the buffer is compressed with an unsupported compression algorithm (XPRESS9/XPRESS10).
-    """
-    identifier = buf[0] >> 3
-    if identifier == COMPRESSION_SCHEME.COMPRESS_7BITASCII:
-        return ((buf[0] & 7) + (8 * len(buf))) // 7
-    if identifier == COMPRESSION_SCHEME.COMPRESS_7BITUNICODE:
-        return 2 * (((buf[0] & 7) + (8 * len(buf))) // 7)
-    if identifier == COMPRESSION_SCHEME.COMPRESS_XPRESS:
-        return struct.unpack("<H", buf[1:3])[0]
-    if identifier in (COMPRESSION_SCHEME.COMPRESS_XPRESS9, COMPRESSION_SCHEME.COMPRESS_XPRESS10):
-        raise NotImplementedError(f"Compression not yet implemented: {COMPRESSION_SCHEME(identifier)}")
-    return None
+__all__ = ["decompress", "decompress_size"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "dissect.cstruct>=4,<5",
     "dissect.util>=3.24,<4",
+    "ntcompress",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

This swaps the compression dispatch in [`compression.py`](https://github.com/fox-it/dissect.database/blob/62f63012578cd429620f239a9a51704738a340bc/dissect/database/ese/compression.py) for [ntcompress](https://pypi.org/project/ntcompress/), which handles every ESE record compression format. XPRESS9 and XPRESS10 no longer raise `NotImplementedError` (the state since #4). LZ4 (scheme 0x07) and SCRUB (scheme 0x04) are also handled now instead of silently passing through as raw bytes.

This was reported in #10 and came up in [fox-it/dissect.esedb#24 (comment)](https://github.com/fox-it/dissect.esedb/pull/24#discussion_r1310601948) where XPRESS10-compressed tagged values in NTDS databases were causing decoding errors. @Schamper [noted](https://github.com/fox-it/dissect.database/issues/10#issuecomment-3557814592) it was not actively being worked on.

## What changed

Two files, net -43 lines.

[`dissect/database/ese/compression.py`](https://github.com/fox-it/dissect.database/blob/62f63012578cd429620f239a9a51704738a340bc/dissect/database/ese/compression.py) goes from 51 lines to 6:

```python
from __future__ import annotations

from ntcompress.ese import decompress
from ntcompress.ese import decompressed_size as decompress_size

__all__ = ["decompress", "decompress_size"]
```

The `decompress(buf)` and `decompress_size(buf)` signatures match the existing call sites in [`record.py` L295](https://github.com/fox-it/dissect.database/blob/62f63012578cd429620f239a9a51704738a340bc/dissect/database/ese/record.py#L295), [`record.py` L338](https://github.com/fox-it/dissect.database/blob/62f63012578cd429620f239a9a51704738a340bc/dissect/database/ese/record.py#L338), and [`table.py` L216](https://github.com/fox-it/dissect.database/blob/62f63012578cd429620f239a9a51704738a340bc/dissect/database/ese/table.py#L216). Nothing else needs to change.

[`pyproject.toml`](https://github.com/fox-it/dissect.database/blob/62f63012578cd429620f239a9a51704738a340bc/pyproject.toml#L27-L30): added `"ntcompress"` to `dependencies`.

## Format coverage

| Scheme ID | Name | Before | After |
|-----------|------|--------|-------|
| 0x01 | 7-bit ASCII | Supported | Supported |
| 0x02 | 7-bit Unicode | Supported | Supported |
| 0x03 | XPRESS | Supported | Supported + CRC verify |
| 0x04 | SCRUB | Silent passthrough | Proper error raised |
| 0x05 | XPRESS9 | NotImplementedError | Supported + CRC verify |
| 0x06 | XPRESS10 | NotImplementedError | Supported + CRC verify |
| 0x07 | LZ4 | Not recognized | Supported |

## ntcompress

[`ntcompress`](https://github.com/StrongWind1/ntcompress) ([docs](https://strongwind1.github.io/ntcompress/), [PyPI](https://pypi.org/project/ntcompress/)) is a pure-Python library with no runtime dependencies, licensed Apache-2.0. Implementing XPRESS9, XPRESS10, LZ4 and SCRUB inline would be substantial and hard to maintain. ntcompress already has the codecs, a large test suite, and no transitive dependencies, so adding it keeps the dependency footprint minimal.

- 107 gold vectors from `esent.dll` and `ntdll.dll` across 16 Windows builds (XP SP3 through Server 2025)
- Decompress output is byte-identical to the Windows APIs
- XPRESS10 decompression verified against `RtlDecompressBufferEx(format=0x0006)` on Server 2025 Build 26100
- XPRESS9 validated against Power BI DataModel files (Analysis Services) and the MIT ESE C reference encoder
- Python >= 3.10, Apache-2.0
- 982 tests passing on 3.10 through 3.14, Linux/Windows/macOS

## Testing

- [x] All 15 databases under [`tests/_data/ese/`](https://github.com/fox-it/dissect.database/tree/main/tests/_data/ese) parsed, every column value accessed -- 236,369 records, 3.7M+ values, zero errors
- [x] External NTDS databases from [skelsec/aesedb](https://github.com/skelsec/aesedb) (Server 2012, 2016, 2019) and [AndrewRathbun/DFIRArtifactMuseum](https://github.com/AndrewRathbun/DFIRArtifactMuseum) (Server 2012 R2, Win11)
- [x] Win11 Build 26100 Windows Search and SRUM databases

[`Windows.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/Windows.edb.gz) is the one that matters most here. It has records using all 7 ESE compression schemes, including the XPRESS9, XPRESS10, LZ4, and SCRUB records that previously failed or were returned as raw bytes.

<details>
<summary>Full fixture results (15 databases)</summary>

| File | Records | Values | Compression |
|------|--------:|-------:|-------------|
| [`Windows.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/Windows.edb.gz) | 5,180 | 77,800 | SEVEN_BIT_UNICODE=19759, XPRESS=300, SEVEN_BIT_ASCII=70, XPRESS9=2, XPRESS10=1, LZ4=1, SCRUB=1 |
| [`ntds/large/ntds.dit.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/ntds/large/ntds.dit.gz) | 78,784 | 2,157,420 | (none) |
| [`ntds/goad/ntds.dit.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/ntds/goad/ntds.dit.gz) | 8,061 | 155,610 | (none) |
| [`ntds/fve/ntds.dit.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/ntds/fve/ntds.dit.gz) | 7,551 | 145,214 | (none) |
| [`ntds/adam/adamntds.dit.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/ntds/adam/adamntds.dit.gz) | 3,072 | 60,027 | (none) |
| [`large.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/large.edb.gz) | 130,166 | 1,106,249 | (none) |
| [`tools/CertLog.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/tools/CertLog.edb.gz) | 609 | 4,743 | SEVEN_BIT_UNICODE=69, XPRESS=9 |
| [`text.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/text.edb.gz) | 220 | 1,816 | XPRESS=3, SEVEN_BIT_ASCII=1 |
| [`multi.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/multi.edb.gz) | 211 | 1,736 | XPRESS=9, SEVEN_BIT_ASCII=1 |
| [`binary.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/binary.edb.gz) | 190 | 1,560 | XPRESS=1, SEVEN_BIT_ASCII=1 |
| [`default.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/default.edb.gz) | 201 | 1,719 | (none) |
| [`basic.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/basic.edb.gz) | 190 | 1,590 | (none) |
| [`index.edb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/index.edb.gz) | 259 | 2,163 | (none) |
| [`tools/Current.mdb.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/tools/Current.mdb.gz) | 992 | | (none) |
| [`tools/SRUDB.dat.gz`](https://github.com/fox-it/dissect.database/blob/main/tests/_data/ese/tools/SRUDB.dat.gz) | 683 | | (none) |

</details>

> [!NOTE]
> Claude was used to help research and write the code for ntcompress. I have read all documentation, all markdown files, and verified the output.